### PR TITLE
fix: bump garminconnect for CVE-2026-54447

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Require `garminconnect>=0.3.5` to address CVE-2026-54447, which could create
+  a world-readable OAuth token store on multi-user Unix systems
+- Existing `garmin_tokens.json` files are not secured until rewritten; restrict their
+  permissions or re-authenticate to rotate tokens if they may have been exposed
+
 ## [1.0.1] - 2026-05-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=3.3.1",
-    "garminconnect>=0.3.3",
+    "garminconnect>=0.3.5",
     "pydantic>=2.10.5",
     "pydantic-settings>=2.7.1",
     "python-dotenv>=1.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.3.1" },
-    { name = "garminconnect", specifier = ">=0.3.3" },
+    { name = "garminconnect", specifier = ">=0.3.5" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.10.5" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
@@ -604,16 +604,16 @@ dev = [
 
 [[package]]
 name = "garminconnect"
-version = "0.3.3"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "curl-cffi" },
     { name = "requests" },
     { name = "ua-generator" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/d9/7ad240d86453de083f0c460ee328e8209232d9d0ee099dcf49439d90be7a/garminconnect-0.3.3.tar.gz", hash = "sha256:f608193d7a90079fa1fd1d86e8d10e88b871b6ab2500372a9dc48358f8c2d386", size = 52234, upload-time = "2026-04-22T12:57:24.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/29/f8e3609f22693020dec65d6285adf12daac459461a09e59dffe12ec7fc08/garminconnect-0.3.6.tar.gz", hash = "sha256:6f90aa282976f7dff880cf53ef4f3ea0d63701fd2a1488c628a66a2a027c2143", size = 61911, upload-time = "2026-06-14T08:05:37.349Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/5a/69af564ff61c87a725e0a6b6ceed4a01569a1caced2c136042c778907244/garminconnect-0.3.3-py3-none-any.whl", hash = "sha256:e11dbbddf20abd60d5c8fbde1e7c688ca175a905237dfec8837ee935a1aca803", size = 47814, upload-time = "2026-04-22T12:57:23.175Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f9/6d69eb2eab9f62ed7e415a606c5ef63e19f27e561d15d7ac7d651997cfad/garminconnect-0.3.6-py3-none-any.whl", hash = "sha256:e05782ab90e63cb9c023407899e2d12dd18132316fd84394ebecd393809d4ffe", size = 57555, upload-time = "2026-06-14T08:05:36.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require `garminconnect>=0.3.5` to exclude versions affected by CVE-2026-54447
- refresh the lock file from `garminconnect` 0.3.3 to 0.3.6
- document remediation guidance for OAuth token stores created by an affected version

## Why

`garminconnect<=0.3.4` could create `garmin_tokens.json` with permissions that
allowed other local users to read the OAuth refresh token on a multi-user Unix
system. Version 0.3.5 hardened the token directory and file permissions.

Existing token files are not secured until the library rewrites them, so the
changelog also advises users to restrict permissions or re-authenticate if a
token may have been exposed.

## Verification

- `uv lock --check --offline`
- `python -m pytest` — 58 passed
- `ruff check .`
- `ruff format --check .` — 34 files already formatted
- `python -m pyright` — 0 errors
